### PR TITLE
building-an-api: refactors flask scaffold to remove app.py

### DIFF
--- a/building-an-api/flask-hello-books.md
+++ b/building-an-api/flask-hello-books.md
@@ -65,7 +65,6 @@ Clone the repo, `cd` into it, and open this project into your favorite text edit
 ├── app
 │   ├── __init__.py
 │   └── routes.py
-├── app.py
 └── requirements.txt
 ```
 

--- a/building-an-api/models-setup.md
+++ b/building-an-api/models-setup.md
@@ -136,7 +136,6 @@ Our current project structure likely looks similar to this:
 │   ├── models
 │   │   └── book.py
 │   └── routes.py
-├── app.py
 └── requirements.txt
 ```
 
@@ -245,7 +244,6 @@ A neat side-effect about generating migrations is that we get to appreciate the 
 │   ├── models
 │   │   └── book.py
 │   └── routes.py
-├── app.py
 ├── migrations
 │   ├── README
 │   ├── alembic.ini

--- a/building-an-api/models.md
+++ b/building-an-api/models.md
@@ -81,7 +81,6 @@ This curriculum's recommended file structure recommends creating a `models` fold
 │   ├── models
 │   │   └── model.py
 │   └── routes.py
-├── app.py
 └── requirements.txt
 ```
 
@@ -127,7 +126,6 @@ This command should create a new folder in our app, `migrations`.
 │   ├── models
 │   │   └── model.py
 │   └── routes.py
-├── app.py
 ├── migrations
 │   ├── README
 │   ├── alembic.ini


### PR DESCRIPTION
Keeping it as a PR because I should check screenshots, check that the update and delete, 404 and more flask queries, env vars, and testing topics don't reference this file