### PR TITLE
Fix typo on branch name in 06 API lesson

### DIFF
--- a/api-6-testing/post-books-test.md
+++ b/api-6-testing/post-books-test.md
@@ -10,7 +10,7 @@ Our goals for this lesson are to:
 
 | Starting Branch | Ending Branch|
 |--|--|
-|`06d-read-one-book-test` |`06e-post-books-test`|
+|`06d-read-one-books-test` |`06e-post-books-test`|
 
 
 # Syntax


### PR DESCRIPTION
[asana ticket](https://app.asana.com/0/1201700438643002/1203237586733922/f)

[branch in reference](https://github.com/AdaGold/hello-books-api/tree/06d-read-one-books-test)