### PR TITLE
Fix typo on hello-books API branch name 

### DIFF
--- a/api-1-setup-read/hello-world-routes.md
+++ b/api-1-setup-read/hello-world-routes.md
@@ -19,7 +19,7 @@ We will:
 
 | Starting Branch | Ending Branch|
 |--|--|
-|`01b-flask-setup` |`01c-hello-world-endpoints`|
+|`01b-flask-setup` |`01c-hello-world`|
 
 ## Defining Endpoints with Blueprint
 


### PR DESCRIPTION
[asana ticket](https://app.asana.com/0/1201700438643002/1203194164029822/f)

[the branch referenced](https://github.com/AdaGold/hello-books-api/tree/01c-hello-world)