### PR TITLE
Adds missing semicolons throughout Intro to SQL

### DIFF
--- a/intro-to-sql/adding-new-records.md
+++ b/intro-to-sql/adding-new-records.md
@@ -42,8 +42,9 @@ VALUES (value1, value2, value3, ...);
 | `( ... )`                        | Contains a list of the column names in the table. _This list is optional, but highly recommended._                                  |
 | `column1, column2, column3, ...` | **Replace this** with a list of the column names in the table. Column names should be comma-separated.                              |
 | `VALUES`                         | A SQL keyword that indicates the values to insert into a new record                                                                 |
-| `( ... );`                       | Contains a list of the values to insert into a new record                                                                           |
-| `value1, value2, value3, ...`;   | **Replace this** with the values for the new record. The order of values **must** exactly match the order of columns listed before. |
+| `( ... )`                       | Contains a list of the values to insert into a new record                                                                           |
+| `value1, value2, value3, ...`   | **Replace this** with the values for the new record. The order of values **must** exactly match the order of columns listed before. |
+| `;`                             | Terminates the SQL query |
 
 The order of values listed **must** exactly match the order of columns listed. In this example, `value1` is the value for `column1` because they're both listed first, and `value3` is the value for `column3` because they're both listed third.
 

--- a/intro-to-sql/deleting-records.md
+++ b/intro-to-sql/deleting-records.md
@@ -61,7 +61,8 @@ WHERE condition;
 | `DELETE FROM`                                       | Keywords that begin an deletion statement                                                   |
 | `table_name`                                        | **Replace this** with the name of the correct table                                         |
 | `WHERE`                                             | Keyword that begins a where-clause, where we determine what gets deleted                    |
-| `condition;`                                        | **Replace this** with a condition that must be **true** in order for a record to be deleted |
+| `condition`                                        | **Replace this** with a condition that must be **true** in order for a record to be deleted |
+| `;`                                                | Terminates the SQL query |
 
 _The `WHERE` clause is optional_. Without a `WHERE` clause, all records within the table will be removed!.
 
@@ -227,7 +228,7 @@ Read through these example SQL statements. For each example, read the code and a
 1. Which record(s) will be removed?
 
 ```sql
-DELETE FROM authors
+DELETE FROM authors;
 ```
 
 <details style="max-width: 700px; margin: auto;">
@@ -264,7 +265,7 @@ WHERE id > 44;
 
 ```sql
 DELETE FROM drivers
-WHERE license_expires = '2020'
+WHERE license_expires = '2020';
 ```
 
 <details style="max-width: 700px; margin: auto;">
@@ -309,7 +310,7 @@ CREATE TABLE hotel_guests (
     guest_id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     guest_name VARCHAR(200),
     is_checked_in BOOLEAN
-)
+);
 ```
 
 ##### !end-question

--- a/intro-to-sql/retrieving-records.md
+++ b/intro-to-sql/retrieving-records.md
@@ -47,7 +47,8 @@ SELECT column1, column2, column3, ... FROM table_name;
 | `SELECT`                                            | A SQL keyword to indicate retrieving records                                                                             |
 | `column1, column2, column3, ...`                    | **Replace this** with a comma-separated list of columns to retrieve, or another expression (such as `*` described below) |
 | `FROM`                                              | A SQL keyword to indicate that these records are from some set of tables                                                 |
-| `table_name;`                                       | **Replace this** with the name of the table being searched. Don't forget the ending semicolon.                           |
+| `table_name`                                       | **Replace this** with the name of the table being searched                           |
+| `;`                              | Terminates the SQL query |
 
 ### The `*` Character
 

--- a/intro-to-sql/sql-setup.md
+++ b/intro-to-sql/sql-setup.md
@@ -233,11 +233,12 @@ CREATE TABLE example_table_name (
 | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `CREATE TABLE`                                | SQL command to create a table                                                                                                       |
 | `example_table_name`                          | **Replace this** with the name of the new table                                                                                     |
-| `( ... );`                                    | The inside of the `()` will contain details about the table. **This statement ends in a semicolon**.                                |
+| `( ... )`                                    | The inside of the `()` will contain details about the table                                |
 | `column_name`                                 | **Replace this** with the name of a new column                                                                                      |
 | `data_type`                                   | **Replace this** with the data type of the new column                                                                               |
 | `constraint_name`                             | **Replace this** with any constraints                                                                                               |
 | `,`                                           | In `CREATE TABLE`, column definitions are comma-separated. We can define multiple columns in this command by comma-separating them. |
+| `;`                                           | Terminates the SQL query |
 
 To create a table with columns and a primary key, we can add `PRIMARY KEY` next to the column definition.
 

--- a/intro-to-sql/updating-records.md
+++ b/intro-to-sql/updating-records.md
@@ -63,7 +63,8 @@ WHERE condition;
 | `SET`                                     | Keyword that begins a set-clause, where we determine what gets updated and how          |
 | `column1 = value1, column2 = value2, ...` | **Replace this** with a comma-separated list of column names `=` to their new values    |
 | `WHERE`                                   | Keyword that begins a where-clause, where we determine what gets updated                |
-| `condition;`                              | **Replace this** with a condition that must be true in order for a record to be updated |
+| `condition`                              | **Replace this** with a condition that must be true in order for a record to be updated |
+| `;`                                      | Terminates the SQL query |
 
 _The `WHERE` clause is optional_. Without a `WHERE` clause, all records within the table will be updated.
 
@@ -382,7 +383,7 @@ CREATE TABLE hotel_guests (
     guest_id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     guest_name VARCHAR(200),
     is_checked_in BOOLEAN
-)
+);
 ```
 
 ##### !end-question


### PR DESCRIPTION
Work started in response to student filing about missing semicolons in the deleting lesson.

I went through the whole Intro to SQL to check for any other missing semicolons, and reorganized the syntax table explanations to highlight the inclusion of the semicolon. Previously the semicolon was just stuck to the end of the last chunk of syntax, which was sometimes an optional chunk. Every example now consistently calls out that the semicolon terminates the SQL query.

Asana: https://app.asana.com/0/1205655776549324/1204482550755381
